### PR TITLE
Adding string indexing and why not number indexing

### DIFF
--- a/_extras/design.md
+++ b/_extras/design.md
@@ -151,6 +151,30 @@ print(a)
 ~~~
 {: .python}
 
+*   Looking at pieces of a string: indexing
+
+~~~
+print(a[0])
+print(a[1])
+print(a[2])
+print(a[-1])
+print(a[-2])
+print(a[-3])
+print(a[5:8])
+print(a[:4])
+print(a[-4:])
+~~~
+{: .python}
+
+Q:  If you set `a = 123`, then what happens if you try to get the second digit?
+A:  Numbers are not stored in the written representation, so they can't be
+    treated like strings.
+~~~
+a = 123
+print(a[1])
+~~~
+{: .python}
+
 *   Use meaningful names for variables.  For example, time
 
 ~~~


### PR DESCRIPTION
When going through the material on lists, I realized that it will be helpful there if people had seen string indexing in the variables section.  I added code for that, and a question to make sure they get that you can index into a string but not into a number.  (If you think it necessary, I can change it to be

```
a = '123'
type(a)
print(a[1])
a = 123
type(a)
print(a[1])
```
